### PR TITLE
Update accountMeta Response to Array

### DIFF
--- a/ERCS/erc-7715.md
+++ b/ERCS/erc-7715.md
@@ -122,7 +122,7 @@ type PermissionResponse = PermissionRequest & {
   accountMeta?: {
     factory: `0x${string}`;
     factoryData: `0x${string}`;
-  };
+  }[];
   signerMeta?: {
     // 7679 userOp building
     userOpBuilder?: `0x${string}`;
@@ -136,7 +136,8 @@ First note that the response contains all of the parameters of the original requ
 
 `context` is a catch-all to identify a permission for revoking permissions or submitting userOps, and can contain non-identifying data as well. It MAY be the `context` as defined in [ERC-7679](./eip-7679.md) and [ERC-7710](./eip-7710.md). See “Rationale” for details.
 
-`accountMeta` is optional but when present then fields for `factory` and `factoryData` are required as defined in [ERC-4337](./eip-4337.md). They are either both specified, or none. If the account has not yet been deployed, the wallet MUST return `accountMeta`, and the DApp MUST deploy the account by calling the `factory` contract with `factoryData` as the calldata.
+`accountMeta` is an optional array but for each element present the fields `factory` and `factoryData` are required as defined in [ERC-4337](./eip-4337.md). When provided, every object in the array must specify both `factory` and `factoryData`, or neither. If the account has not yet been deployed, the wallet MUST return an `accountMeta` array with at least one object, and the DApp MUST deploy the account by calling the `factory` contract with the corresponding `factoryData` as the calldata. This design supports multiple potential account deployments or configurations within a single response.
+
 
 `signerMeta` is dependent on the account type. If the signer type is `wallet` then it's not required. If the signer type is `key` or `keys` then `userOpBuilder` is required as defined in [ERC-7679](./eip-7679.md). If the signer type is `account` then `delegationManager` is required as defined in [ERC-7710](./eip-7710.md).
 


### PR DESCRIPTION
## Why
Updating accountMeta to be an array allows for multiple potential account deployments within a single response. This enhancement maintains the original functionality—deploying a single account—by using a single-element array. However, by using an array, we gain the flexibility to handle scenarios where multiple accounts need to be deployed to fulfill a given permission. This approach not only adds versatility but also future-proofs the standard, enabling it to support more complex use cases without requiring further modifications. This change anticipates evolving needs and positions the standard to accommodate a broader range of deployment strategies while retaining its original intent.