### PR TITLE
Update 7715: Remove policies and update signer types

### DIFF
--- a/ERCS/erc-7715.md
+++ b/ERCS/erc-7715.md
@@ -2,7 +2,7 @@
 eip: 7715
 title: Grant Permissions from Wallets
 description: Adds JSON-RPC method for granting permissions from a wallet
-author: Luka Isailovic (@lukaisailovic), Derek Rein (@arein), Dan Finlay (@danfinlay), Derek Chiang (@derekchiang), Fil Makarov (@filmakarov), Pedro Gomes (@pedrouid), Conner Swenberg (@ilikesymmetry)
+author: Luka Isailovic (@lukaisailovic), Derek Rein (@arein), Dan Finlay (@danfinlay), Derek Chiang (@derekchiang), Fil Makarov (@filmakarov), Pedro Gomes (@pedrouid), Conner Swenberg (@ilikesymmetry), Lukas Rosario (@lukasrosario)
 discussions-to: https://ethereum-magicians.org/t/erc-7715-grant-permissions-from-wallets/20100
 status: Draft
 type: Standards Track
@@ -57,15 +57,11 @@ type PermissionRequest = {
     type: string; // enum defined by ERCs
     data: Record<string, any>;
   };
-  permission: {
-    type: string; // enum defined by ERCs
-    data: Record<string, any>;
-  };
-  policies: {
+  permissions: {
     type: string; // enum defined by ERCs
     data: Record<string, any>;
   }[];
-};
+}[];
 ```
 
 `chainId` defines the chain with [EIP-155](./eip-155.md) which applies to this permission request and all addresses can be found defined by other parameters.
@@ -76,9 +72,7 @@ type PermissionRequest = {
 
 `signer` is a field that identifies the key or account associated with the permission or alternatively the wallet will manage the session. See the “Signers” section for details.
 
-`permission` defines the allowed behavior the signer can do on behalf of the account. See the “Permissions” section for details.
-
-`policies` defines additional constraints on top of the base resitrctions imposed by the permission. See the “Policies” section for details.
+`permissions` defines the allowed behavior the signer can do on behalf of the account. See the “Permissions” section for details.
 
 **Request example**:
 
@@ -96,20 +90,14 @@ An array of `PermissionRequest` objects is the final `params` field expected by 
                 address:'0x016562aA41A8697720ce0943F003141f5dEAe006',
             }
         },
-        permission: {
+        permissions: [
+          {
             type: 'native-token-transfer',
             data: {
                 allowance: '0x1DCD6500'
             }
-        },
-        policies: [
-            {
-                type: 'gas-limit',
-                data: {
-                    limit: '0x1DCD6500'
-                }
-            }
-        ]
+          }
+        ],
     }
 ]
 ```
@@ -159,19 +147,13 @@ An array of `PermissionResponse` objects is the final `result` field expected by
                 address:'0x016562aA41A8697720ce0943F003141f5dEAe006',
             }
         },
-        permission: {
+        permissions: [
+          {
             type: 'native-token-transfer',
             data: {
                 allowance: '0x1DCD65000000'
             }
-        },
-        policies: [
-            {
-                type: 'gas-limit',
-                data: {
-                    limit: '0x1DCD65'
-                }
-            }
+          },
         ]
         // response-specific fields
         context: "0x0x016562aA41A8697720ce0943F003141f5dEAe0060000771577157715"
@@ -197,13 +179,13 @@ type RevokePermissionsRequestParams = {
 type RevokePermissionsResponseResult = {};
 ```
 
-### Signer & Permission/Policy Types
+### Signer & Permission Types
 
-In this ERC, we specify a list of signers, permissions and policies that we expect to be commonly used.
+In this ERC, we specify a list of signers and permissions that we expect to be commonly used.
 
-This ERC does not specify an exhaustive list of signer, permission or policy types, since we expect more signer, permission and policy types to be developed as wallets get more advanced. A signer, permission or policy type is valid as long as both the DApp and the wallet are willing to support it.
+This ERC does not specify an exhaustive list of signer or permission types, since we expect more signer and permission types to be developed as wallets get more advanced. A signer or permission type is valid as long as both the DApp and the wallet are willing to support it.
 
-However, if two signers or two permissions or policies share the same type name, a DApp could request with one type of signer, permission or policy while the wallet grants another. Therefore, it’s important that no two signers or two permissions or two policies share the same type. Therefore, new signer, permission or policy types should be specified in ERCs, either in this ERC as an amendment or in another ERC.
+However, if two signers or two permissions share the same type name, a DApp could request with one type of signer or permission while the wallet grants another. Therefore, it’s important that no two signers or two permissions share the same type. Therefore, new signer or permission types should be specified in ERCs, either in this ERC as an amendment or in another ERC.
 
 #### Signers
 
@@ -216,21 +198,23 @@ type WalletSigner = {
 };
 
 // A signer representing a single key.
-// `id` is a did:key identifier and can therefore represent both Secp256k1 or Secp256r1 keys, among other key types.
+// "Key" types are explicitly secp256r1 (p256) or secp256k1, and the public keys are hex-encoded.
 type KeySigner = {
   type: "key";
   data: {
-    id: string;
+    type: "secp256r1" | "secp256k1";
+    publicKey: `0x${string}`;
   };
 };
 
 // A signer representing a multisig signer.
-// Each element of `ids` is a did:key identifier just like the `key` signer.
+// Each element of `data` is explicitly an secp256r1 (p256) or secp256k1 key, and the public keys are hex-encoded
 type MultiKeySigner = {
   type: "keys";
   data: {
-    ids: string[];
-  };
+    type: "secp256r1" | "secp256k1";
+    publicKey: `0x${string}`;
+  }[];
 };
 
 // An account that can be granted with permissions as in ERC-7710.
@@ -281,13 +265,9 @@ type ERC1155TokenTransferPermission = {
     };
   };
 };
-```
 
-#### Policies
-
-```tsx
 // The maximum gas limit spent in the session in total
-type GasLimitPolicy = {
+type GasLimitPermission = {
   type: "gas-limit";
   data: {
     limit: "0x..."; // hex value
@@ -295,7 +275,7 @@ type GasLimitPolicy = {
 };
 
 // The number of calls the session can make in total
-type CallLimitPolicy = {
+type CallLimitPermission = {
   type: "call-limit";
   data: {
     count: number;
@@ -303,7 +283,7 @@ type CallLimitPolicy = {
 };
 
 // The number of calls the session can make during each interval
-type RateLimitPolicy = {
+type RateLimitPermission = {
   type: "rate-limit";
   data: {
     count: number; // the number of times during each interval
@@ -312,7 +292,7 @@ type RateLimitPolicy = {
 };
 
 // The amount of Native Token that can be spent by a permission
-type NativeTokenSpendLimitPolicy = {
+type NativeTokenSpendLimitPermission = {
   type: "spent-limit";
   data: {
     allowance: "0x..."; // hex value
@@ -357,7 +337,7 @@ Upon receiving this request, the wallet MUST send the calls in accordance with t
 
 If the wallet supports [ERC-5792](./eip-5792.md), wallet SHOULD respond on **`wallet_getCapabilities`** request using the `permissions` key.
 
-The wallet SHOULD include `signerTypes` (`string[]`), `permissionTypes` (`string[]`) and `policyTypes` (`string[]`) in the response, to specify the signer types and permission types it supports.
+The wallet SHOULD include `signerTypes` (`string[]`) and `permissionTypes` (`string[]`) in the response, to specify the signer types and permission types it supports.
 Example:
 
 ```json
@@ -366,8 +346,7 @@ Example:
     "permissions": {
       "supported": true,
       "signerTypes": ["keys", "account"],
-      "permissionTypes": ["erc20-token-transfer", "erc721-token-transfer"],
-      "policyTypes": ["rate-limit", "gas-limit"]
+      "permissionTypes": ["erc20-token-transfer", "erc721-token-transfer"]
     }
   }
 }
@@ -383,8 +362,7 @@ Example:
   "sessionProperties": {
     "permissions": "true",
     "signerTypes": "keys,account",
-    "permissionTypes": "erc20-token-transfer,erc721-token-transfer",
-    "policyTypes": "rate-limit,gas-limit"
+    "permissionTypes": "erc20-token-transfer,erc721-token-transfer"
   }
 }
 ```
@@ -471,14 +449,9 @@ const permissionsResponse = await bob.request({
     },
     permissions: [{
       type: 'native-token-transfer',
-      policies: [{
-        type: 'gas-limit',
-        data: '0x0186A0'
-      }]
       data: {
         allowance: '0x0DE0B6B3A7640000'
       },
-      required: true
     }],
     expiry: Math.floor(Date.now() / 1000) + 3600 // 1 hour from now
   }]

--- a/ERCS/erc-7715.md
+++ b/ERCS/erc-7715.md
@@ -351,6 +351,7 @@ Example:
     "permissions": {
       "supported": true,
       "signerTypes": ["keys", "account"],
+      "keyTypes": ["secp256k1", "secp256r1"],
       "permissionTypes": ["erc20-token-transfer", "erc721-token-transfer"]
     }
   }
@@ -452,12 +453,20 @@ const permissionsResponse = await bob.request({
         id: alice.address
       }
     },
-    permissions: [{
-      type: 'native-token-transfer',
-      data: {
-        allowance: '0x0DE0B6B3A7640000'
+    permissions: [
+      {
+        type: 'native-token-transfer',
+        data: {
+          allowance: '0x0DE0B6B3A7640000'
+        },
       },
-    }],
+      {
+        type: 'gas-limit';
+        data: {
+          limit: '0x0186A0',
+        },
+      },
+    ],
     expiry: Math.floor(Date.now() / 1000) + 3600 // 1 hour from now
   }]
 });

--- a/ERCS/erc-7715.md
+++ b/ERCS/erc-7715.md
@@ -197,24 +197,27 @@ type WalletSigner = {
   data: {};
 };
 
+// The types of keys that are supported for the following `key` and `keys` signer types.
+type KeyType = "secp256r1" | "secp256k1" | "ed25519" | "schnorr";
+
 // A signer representing a single key.
 // "Key" types are explicitly secp256r1 (p256) or secp256k1, and the public keys are hex-encoded.
 type KeySigner = {
   type: "key";
   data: {
-    type: "secp256r1" | "secp256k1";
+    type: KeyType;
     publicKey: `0x${string}`;
   };
 };
 
 // A signer representing a multisig signer.
-// Each element of `data` is explicitly an secp256r1 (p256) or secp256k1 key, and the public keys are hex-encoded
+// Each element of `publicKeys` are all explicitly the same `KeyType`, and the public keys are hex-encoded.
 type MultiKeySigner = {
   type: "keys";
   data: {
-    type: "secp256r1" | "secp256k1";
-    publicKey: `0x${string}`;
-  }[];
+    type: KeyType;
+    publicKeys: `0x${string}`[];
+  };
 };
 
 // An account that can be granted with permissions as in ERC-7710.

--- a/ERCS/erc-7715.md
+++ b/ERCS/erc-7715.md
@@ -215,8 +215,10 @@ type KeySigner = {
 type MultiKeySigner = {
   type: "keys";
   data: {
-    type: KeyType;
-    publicKeys: `0x${string}`[];
+    keys: {
+      type: KeyType;
+      publicKey: `0x${string}`;
+    }[];
   };
 };
 

--- a/ERCS/erc-7715.md
+++ b/ERCS/erc-7715.md
@@ -295,14 +295,6 @@ type RateLimitPermission = {
     interval: number; // in seconds
   };
 };
-
-// The amount of Native Token that can be spent by a permission
-type NativeTokenSpendLimitPermission = {
-  type: "spent-limit";
-  data: {
-    allowance: "0x..."; // hex value
-  };
-};
 ```
 
 ### Wallet-managed Sessions


### PR DESCRIPTION
- remove policies. all constraints are specified in the `permissions` field.
- update signer types. specify secp256r1 or secp256k1 `key` types.